### PR TITLE
Initial docs for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,28 @@ Tokens can also represent more complex concepts:
 
 The tools in this monorepo - which are published as separate packages - make working with and converting your design token data a breeze! Navigate to each folder below for installation instructions and instructions on how to use.
 
-## @knapsack-labs/token-format-utils
+## Packages
+
+### @knapsack-labs/token-format-utils
 
 `/packages/token-format-utils`
 
-Share utilities between the following packages.
+> Share utilities between the following packages.
 
-## @knapsack-labs/token-format-spec
+### @knapsack-labs/token-format-spec
 
 `/packages/token-format-spec`
 
-Typescript types describing the shape and behavior of token spec data.
+> Typescript types describing the shape and behavior of token spec data.
 
-## @knapsack-labs/token-data
+### @knapsack-labs/token-data
 
 `/packages/token-data`
 
-The main utility for parsing raw tokens json into a class that makes reading and manipulating token data easier.
+> The main utility for parsing raw tokens json into a class that makes reading and manipulating token data easier.
 
-## @knapsack-labs/token-asset-converter-web
+### @knapsack-labs/token-asset-converter-web
 
 `/packages/token-format-utils`
 
-Convert token data into web assets like CSS, Sass, Less.
+> Convert token data into web assets like CSS, Sass, Less.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The tools in this monorepo - which are published as separate packages - make wor
 
 `/packages/token-data`
 
-> The main utility for parsing raw tokens json into a class that makes reading and manipulating token data easier.
+> The main utility for parsing raw tokens json into a flattened, de-referenced, developer-friendly intermediate format.
 
 ### @knapsack-labs/token-asset-converter-web
 

--- a/packages/token-asset-converter-web/readme.md
+++ b/packages/token-asset-converter-web/readme.md
@@ -1,1 +1,60 @@
+# @knapsack-labs/token-asset-converter-web
 
+> Convert token data into web assets like CSS, Sass, Less.
+
+## Install
+
+Using npm:
+
+```bash
+npm install --save @knapsack-labs/token-asset-converter-web
+```
+
+Using yarn:
+
+```bash
+yarn add @knapsack-labs/token-asset-converter-web
+```
+
+## Use
+
+```ts
+import { TokenSrcGroup } from '@knapsack-labs/token-format-spec';
+import { convertTokenGroupToData } from '@knapsack-labs/token-data';
+import {
+  convertTokenDataToCss,
+  convertTokenDataToScss,
+} from './web-asset-converters';
+
+const tokenSrcGroup: TokenSrcGroup = {
+  color: {
+    red: {
+      500: {
+        $value: '#ff0000',
+      },
+    },
+    'brand-red': {
+      $value: '{red.500}',
+    },
+  },
+};
+
+// Asset converters expect the the tokens data to be in the intermediate format
+const tokensData = convertTokenGroupToData(tokenSrcGroup);
+
+const cssString = convertTokenDataToCss(tokensData.tokens);
+
+// cssString value:
+//
+// :root {
+//   --color-red-500: #ff0000;
+//   --color-brand-red: var(--color-red-500);
+// }
+
+const scssString = convertTokenDataToScss(tokensData.tokens);
+
+// scssString value:
+//
+// $color-red-500: #ff0000;
+// $color-brand-red: $color-red-500;
+```

--- a/packages/token-asset-converter-web/readme.md
+++ b/packages/token-asset-converter-web/readme.md
@@ -10,12 +10,6 @@ Using npm:
 npm install --save @knapsack-labs/token-asset-converter-web
 ```
 
-Using yarn:
-
-```bash
-yarn add @knapsack-labs/token-asset-converter-web
-```
-
 ## Use
 
 ```ts

--- a/packages/token-data/readme.md
+++ b/packages/token-data/readme.md
@@ -10,12 +10,6 @@ Using npm:
 npm install --save @knapsack-labs/token-data
 ```
 
-Using yarn:
-
-```bash
-yarn add @knapsack-labs/token-data
-```
-
 ## Use
 
 ```ts
@@ -24,19 +18,88 @@ import { convertTokenGroupToData } from '@knapsack-labs/token-data';
 
 const tokenSrcGroup: TokenSrcGroup = {
   color: {
+    $type: 'color',
     red: {
       500: {
         $value: '#ff0000',
       },
     },
     'brand-red': {
-      $value: '{red.500}',
+      $value: '{color.red.500}',
     },
   },
 };
 
 const tokenData = convertTokenGroupToData(tokenSrcGroup);
-
-// TODO: show token data format here
-console.log(tokenData);
+// `tokenData` shown below:
+{
+  tokensById: {
+    'color.red.500': {
+      type: 'color',
+      value: '#ff0000',
+      id: 'color.red.500',
+      originalValue: '#ff0000',
+      kind: 'static',
+    },
+    'color.brand-red': {
+      type: 'color',
+      value: '#ff0000',
+      id: 'color.brand-red',
+      originalValue: '{color.red.500}',
+      kind: 'ref',
+      referencedTokenId: 'color.red.500',
+    },
+  },
+  tokens: [
+    {
+      type: 'color',
+      value: '#ff0000',
+      id: 'color.brand-red',
+      originalValue: '{color.red.500}',
+      kind: 'ref',
+      referencedTokenId: 'color.red.500',
+    },
+    {
+      type: 'color',
+      value: '#ff0000',
+      id: 'color.red.500',
+      originalValue: '#ff0000',
+      kind: 'static',
+    },
+  ],
+  groupsById: {
+    color: {
+      id: 'color',
+      type: 'color',
+      children: {
+        groupIds: ['color.red'],
+        tokenIds: ['color.brand-red'],
+      },
+    },
+    'color.red': {
+      id: 'color.red',
+      children: {
+        groupIds: [],
+        tokenIds: ['color.red.500'],
+      },
+    },
+  },
+  groups: [
+    {
+      id: 'color',
+      type: 'color',
+      children: {
+        groupIds: ['color.red'],
+        tokenIds: ['color.brand-red'],
+      },
+    },
+    {
+      id: 'color.red',
+      children: {
+        groupIds: [],
+        tokenIds: ['color.red.500'],
+      },
+    },
+  ],
+};
 ```

--- a/packages/token-data/readme.md
+++ b/packages/token-data/readme.md
@@ -1,1 +1,42 @@
+# @knapsack-labs/token-data
 
+> The main utility for parsing raw tokens json into a flattened, de-referenced, developer-friendly intermediate format.
+
+## Install
+
+Using npm:
+
+```bash
+npm install --save @knapsack-labs/token-data
+```
+
+Using yarn:
+
+```bash
+yarn add @knapsack-labs/token-data
+```
+
+## Use
+
+```ts
+import { TokenSrcGroup } from '@knapsack-labs/token-format-spec';
+import { convertTokenGroupToData } from '@knapsack-labs/token-data';
+
+const tokenSrcGroup: TokenSrcGroup = {
+  color: {
+    red: {
+      500: {
+        $value: '#ff0000',
+      },
+    },
+    'brand-red': {
+      $value: '{red.500}',
+    },
+  },
+};
+
+const tokenData = convertTokenGroupToData(tokenSrcGroup);
+
+// TODO: show token data format here
+console.log(tokenData);
+```

--- a/packages/token-format-spec/readme.md
+++ b/packages/token-format-spec/readme.md
@@ -1,1 +1,49 @@
+# @knapsack-labs/token-format-spec
 
+> This package contains TypeScript types describing the shape and behavior of token spec data. There are also included validators to ensure token data shape meets the spec.
+
+## Install
+
+Using npm:
+
+```bash
+npm install --save @knapsack-labs/token-format-spec
+```
+
+Using yarn:
+
+```bash
+yarn add @knapsack-labs/token-format-spec
+```
+
+## Use
+
+For example, `validateName()`, which is a default export:
+
+```ts
+import { validateTokenSrcGroup } from '@knapsack-labs/token-format-spec';
+import { TokenSrcGroup } from '@knapsack-labs/token-format-spec';
+
+const tokenSrcGroup: TokenSrcGroup = {
+  color: {
+    red: {
+      500: {
+        $value: '#ff0000',
+      },
+    },
+    blue: {
+      500: {
+        $value: '#0000ff',
+      },
+    },
+  },
+};
+
+const results = validateTokenSrcGroup(tokenSrcGroup);
+
+if (results.errors.length) {
+  throw new Error(`Tokens are bad: ${results.errorMsg}`);
+}
+
+doStuffWithMyTokens(results.data);
+```

--- a/packages/token-format-spec/readme.md
+++ b/packages/token-format-spec/readme.md
@@ -18,8 +18,6 @@ yarn add @knapsack-labs/token-format-spec
 
 ## Use
 
-For example, `validateName()`, which is a default export:
-
 ```ts
 import { validateTokenSrcGroup } from '@knapsack-labs/token-format-spec';
 import { TokenSrcGroup } from '@knapsack-labs/token-format-spec';

--- a/packages/token-format-spec/readme.md
+++ b/packages/token-format-spec/readme.md
@@ -10,12 +10,6 @@ Using npm:
 npm install --save @knapsack-labs/token-format-spec
 ```
 
-Using yarn:
-
-```bash
-yarn add @knapsack-labs/token-format-spec
-```
-
 ## Use
 
 ```ts

--- a/packages/token-format-utils/readme.md
+++ b/packages/token-format-utils/readme.md
@@ -18,8 +18,6 @@ yarn add @knapsack-labs/token-format-utils
 
 ## Use
 
-For example, `validateName()`, which is a default export:
-
 ```ts
 import { validateName } from `@knapsack-labs/token-format-utils`;
 

--- a/packages/token-format-utils/readme.md
+++ b/packages/token-format-utils/readme.md
@@ -1,1 +1,36 @@
+# @knapsack-labs/token-format-utils
 
+> This package contains shared libraries used by other token packages and will likely not be used standalone.
+
+## Install
+
+Using npm:
+
+```bash
+npm install --save @knapsack-labs/token-format-utils
+```
+
+Using yarn:
+
+```bash
+yarn add @knapsack-labs/token-format-utils
+```
+
+## Use
+
+For example, `validateName()`, which is a default export:
+
+```ts
+import { validateName } from `@knapsack-labs/token-format-utils`;
+
+const badTokenName = '$bad.token.name}'
+
+const errorMessages = validateName(badTokenName);
+
+if (errorMessages.length === 0) {
+  console.log('Congrats, your token name is valid!')
+} else {
+  console.log(errorMessages)
+}
+
+```

--- a/packages/token-format-utils/readme.md
+++ b/packages/token-format-utils/readme.md
@@ -10,12 +10,6 @@ Using npm:
 npm install --save @knapsack-labs/token-format-utils
 ```
 
-Using yarn:
-
-```bash
-yarn add @knapsack-labs/token-format-utils
-```
-
 ## Use
 
 ```ts


### PR DESCRIPTION
- token-format-utils starting readme
- token-format-spec initial docs
- initial token-data docs
- token-asset-converter-web initial docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.3--canary.2.4810983279.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-labs/token-asset-converter-web@1.0.3--canary.2.4810983279.0
  npm install @knapsack-labs/token-data@1.0.3--canary.2.4810983279.0
  npm install @knapsack-labs/token-format-spec@1.0.3--canary.2.4810983279.0
  npm install @knapsack-labs/token-format-utils@1.0.3--canary.2.4810983279.0
  # or 
  yarn add @knapsack-labs/token-asset-converter-web@1.0.3--canary.2.4810983279.0
  yarn add @knapsack-labs/token-data@1.0.3--canary.2.4810983279.0
  yarn add @knapsack-labs/token-format-spec@1.0.3--canary.2.4810983279.0
  yarn add @knapsack-labs/token-format-utils@1.0.3--canary.2.4810983279.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
